### PR TITLE
Removing encryption_required from credential request

### DIFF
--- a/_specifications/swiss-profile-issuance.md
+++ b/_specifications/swiss-profile-issuance.md
@@ -110,7 +110,7 @@ Wallets **MUST** support key attestation.<br>
 Requests **MUST** be sent with a DPoP Header.<br>
 `credential_identifier` is **NOT SUPPORTED**.<br>
 `credential_configuration_id` **MUST** be set to `credential_configuration_id` from the credential offer.<br>
-`credential_response_encryption` **MUST** be used and `encryption_required` **MUST** be `true`.<br>
+`credential_response_encryption` **MUST** be used.<br>
 
 ### 8.3. Credential Response
 The number of elements in the credentials array **MUST** match the exact number of keys that the Wallet has provided via the proofs parameter of the Credential Request.<br>


### PR DESCRIPTION
Hi,

This relates to [the previous issue regarding request and response encryption](https://github.com/swiyu-admin-ch/swiyu-admin-ch.github.io/issues/44). I overlooked the following difference between the credential request and the credential issuer metadata:

`credential_response_encryption` is defined differently in the [credential request](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-request) and the [credential issuer metadata](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-issuer-metadata-p): `encryption_required` is only present in the credential issuer metadata and not in the credential request.

The presence of `credential_response_encryption` in the **credential request** is sufficient to enforce response encryption: [OID4VCI 1.0 8.3](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-response): "If the Client requested an encrypted response by including the credential_response_encryption object in the request, the Credential Issuer MUST encode the information in the Credential Response as specified by [Section 10](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#encrypted-messages)..." i.e. encrypting the response.

In contrast, `encryption_required` is added in the **credential issuer metadata** to require the client to request encrypted responses: [OID4VCI 1.0 8.2](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-request): "The Credential Issuer indicates support for encrypted responses by including the credential_response_encryption parameter in the Credential Issuer Metadata. The Client MAY request encrypted responses by providing its encryption parameters in the Credential Request when encryption_required is false and MUST do so when encryption_required is true."

I hope this did not cause too much confusion.

Best,
Xenia